### PR TITLE
Add Modals to "Learn More" Cards in Services Section

### DIFF
--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -2,7 +2,8 @@
 import { motion } from "framer-motion"
 import { Dumbbell, Users, Clock, Target } from "lucide-react"
 import Button from "./ui/Button"
-
+import { useState } from "react"
+import Modal from "./ui/Modal"
 const services = [
   {
     icon: Dumbbell,
@@ -27,6 +28,7 @@ const services = [
 ]
 
 const Services = () => {
+  const [modal,setModal] = useState();
   return (
     <section className="py-20 bg-black">
       <div className="container mx-auto px-6">
@@ -61,11 +63,25 @@ const Services = () => {
               </div>
               <h3 className="text-xl font-bold text-white mb-4">{service.title}</h3>
               <p className="text-gray-400 mb-6 leading-relaxed">{service.description}</p>
-              <Button className="bg-lime-400 hover:bg-lime-500 text-black font-semibold w-full">Learn More</Button>
+              {/* <Button className="bg-lime-400 hover:bg-lime-500 text-black font-semibold w-full">Learn More</Button> */}
+              <div onClick={()=>setModal(service)}  className="border border-gray-900  hover:border-lime-400 w-fit p-2 ">
+
+              <button className="text-white">Learn More</button>
+              </div>
             </motion.div>
           ))}
         </div>
       </div>
+
+       {/* Modal Component */}
+      <Modal
+        open={!!modal}
+        onClose={() => setModal(null)}
+        title={modal?.title}
+        icon={modal?.icon}
+        content={modal?.description}
+      />
+
     </section>
   )
 }

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -9,23 +9,53 @@ const services = [
     icon: Dumbbell,
     title: "Quality Training",
     description: "Professional equipment and expert guidance for optimal results",
+    more: [
+      "Certified personal trainers for customized routines",
+      "Industry-grade gym equipment for all fitness levels",
+      "Focus on form correction, injury prevention, and posture",
+      "Training plans adjusted to goals: weight loss, muscle gain, etc.",
+      "Track progress with regular performance assessments"
+    ],
   },
   {
     icon: Users,
     title: "Strength Build",
     description: "Build muscle and increase strength with our proven programs",
+     more: [
+      "Structured strength programs: beginner to advanced",
+      "Emphasis on compound lifts (squat, deadlift, bench, etc.)",
+      "Periodic progressive overload for consistent growth",
+      "Nutrition and recovery guidance included",
+      "Group strength training sessions and 1:1 coaching"
+    ],
   },
   {
     icon: Clock,
     title: "Fat Loss",
     description: "Effective fat burning workouts designed for maximum efficiency",
+     more: [
+      "HIIT, circuit training, and metabolic workouts",
+      "Real-time calorie tracking and goal setting",
+      "Nutrition plans tailored for fat reduction",
+      "Weekly check-ins and body fat measurements",
+      "Cardio & strength combo plans for lasting results"
+    ],
   },
   {
     icon: Target,
     title: "24/7 Support",
     description: "Round-the-clock support and guidance from our expert team",
+    more: [
+      "Chat support with trainers and dietitians anytime",
+      "Video tutorials & FAQs accessible 24/7",
+      "Emergency support during home workouts",
+      "Personalized reminders, tips, and motivation",
+      "Instant feedback via mobile app or web portal"
+    ],
   },
 ]
+
+
 
 const Services = () => {
   const [modal,setModal] = useState();
@@ -79,7 +109,7 @@ const Services = () => {
         onClose={() => setModal(null)}
         title={modal?.title}
         icon={modal?.icon}
-        content={modal?.description}
+        content={modal?.more}
       />
 
     </section>

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+
+const backdrop = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};
+const modal = {
+  hidden: { scale: 0.9, opacity: 0, y: 20 },
+  visible: { scale: 1, opacity: 1, y: 0 },
+  exit: { scale: 0.9, opacity: 0, y: 20 },
+};
+
+const Modal = ({ open, onClose, title, icon: Icon, content }) => {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 px-4"
+          variants={backdrop}
+          initial="hidden"
+          animate="visible"
+          exit={"hidden"}
+          onClick={onClose}
+        >
+          <motion.div
+            variants={modal}
+            initial="hidden"
+            animate="visible"
+            exit={"exit"}
+            transition={{ duration: 0.3 }}
+            className="bg-green-300 max-w-lg w-full rounded-xl p-6 relative shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="absolute top-3 right-3 text-gray-500 hover:text-gray-800"
+              onClick={onClose}
+            >
+              <X className="w-6 h-6" />
+            </button>
+
+            <div className="flex items-center gap-4 mb-4">
+              <div className="bg-lime-400 p-3 rounded-lg">
+                <Icon className="w-6 h-6 text-black" />
+              </div>
+              <h3 className="text-2xl font-bold">{title}</h3>
+            </div>
+
+            <p className="text-gray-700">{content}</p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default Modal;

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -34,20 +34,29 @@ const Modal = ({ open, onClose, title, icon: Icon, content }) => {
             onClick={(e) => e.stopPropagation()}
           >
             <button
-              className="absolute top-3 right-3 text-gray-500 hover:text-gray-800"
+              className="absolute  top-3 right-3 text-gray-800  transition-transform duration-200 ease-in-out hover:-rotate-45 hover:scale-110 mt-4"
               onClick={onClose}
             >
-              <X className="w-6 h-6" />
+              <X className="w-8 h-8" /> 
             </button>
 
-            <div className="flex items-center gap-4 mb-4">
-              <div className="bg-lime-400 p-3 rounded-lg">
+            <div className="flex items-center gap-4 mb-4 ">
+              <div className="bg-lime-300 p-3 rounded-lg">
                 <Icon className="w-6 h-6 text-black" />
               </div>
-              <h3 className="text-2xl font-bold">{title}</h3>
+              <h3 className="text-3xl font-bold ">{title}</h3>
             </div>
+            <ul className="list-disc p-5">
 
-            <p className="text-gray-700">{content}</p>
+            {content.map((items,index)=>(
+              <li className="text-xl hover:scale-105 hover:transition-all hover:duration-150 hover:cursor-pointer font-semibold my-2" key={index}>{items}</li>
+              
+            ))}
+            </ul>
+
+
+
+            {/* <p className="text-gray-700">{content}</p> */}
           </motion.div>
         </motion.div>
       )}


### PR DESCRIPTION
###  Description

This pull request implements dynamic modal functionality for each "Learn More" button in the Services component. The modal provides detailed, point-by-point information about each service card, utilizing Tailwind CSS and Framer Motion for styling and animation.

### Issue Id : @#19

### Preview Features

- Open modal on clicking “Learn More” for any card.
- Smooth opening/closing transitions.
- Glassmorphic backdrop with blur effect.
- Detailed info displayed as a list inside the modal.

### Screenshots

<img width="1877" height="903" alt="FitolutionPic 1" src="https://github.com/user-attachments/assets/a440abc9-87d8-4e5a-9570-1ac30fa91f04" />
